### PR TITLE
Update check_mailscanner_service.php

### DIFF
--- a/pkg-mailscanner/files/check_mailscanner_service.php
+++ b/pkg-mailscanner/files/check_mailscanner_service.php
@@ -55,7 +55,7 @@ if ( $found[4] == 0 ) {
 
 foreach ($config['installedpackages']['menu'] as $menu) {
 	switch ($menu['name']) {
-		case 'mailscanner':
+		case 'Mailscanner':
 			$found[0]++;
 			break;
 	}


### PR DESCRIPTION
Fix menu duplication on subsequent installs - looking for menu 'mailscanner' not 'Mailscanner'